### PR TITLE
Error for Libs in package_config function

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -80,9 +80,11 @@ class PkgConfigModule(ExtensionModule):
                         yield l
                     else:
                         install_dir = l.get_custom_install_dir()[0]
-                        if install_dir:
+                        if install_dir is False:
+                            continue
+                        if isinstance(install_dir, str):
                             yield '-L${prefix}/%s ' % install_dir
-                        else:
+                        else:  # install_dir is True
                             yield '-L${libdir}'
                         lname = self._get_lname(l, msg, pcfile)
                         # If using a custom suffix, the compiler may not be able to


### PR DESCRIPTION
Without specifying a custom install directory string, get_custom_install_dir() returns True. So for the `Libs` entry I was getting this:

  Libs: -L${prefix}/True -lfoo

Now it behaves as expected:

  Libs: -L${libdir} -lfoo